### PR TITLE
added constants for encoder and decoder

### DIFF
--- a/src/dreamer_node/util/constants.py
+++ b/src/dreamer_node/util/constants.py
@@ -158,29 +158,11 @@ class Config:
             "action_repeat": 1,
             "envs": 1,
             "train_ratio": 512,
-            "encoder": {"mlp_keys": ".*", "cnn_keys": "$^"},
-            "decoder": {"mlp_keys": ".*", "cnn_keys": "$^"},
+            "encoder": {"mlp_keys": "lidar", "cnn_keys": "image", "mlp_units":512,
+                        "act": "SiLU", "cnn_depth": 32, "mlp_layers":4, "symlog_inpts":False,
+                        "norm": True, "kernel_size":4, "minres":4},
+            "decoder": {"mlp_keys": "lidar", "cnn_keys": "image", "norm": True,
+                        "act": "SiLU", "mlp_units":512,"cnn_depth": 32, "mlp_layers":4,
+                        "kernel_size":4,"minres":4, "cnn_sigmoid": True, "image_dist": "mse", 
+                        "vector_dist": "normal", "outscale": 1.0},
         }
-
-        # PARAMS for networks.MultiEncoder for image data and LiDAR data
-        self.shapes = {
-            "image": (64, 64, 3),  # Image input
-            "lidar": (1080,),      # LiDAR input
-        }
-        self.encoder_cnn_keys = "image"
-        self.encoder_mlp_keys = "lidar"
-        self.encoder_cnn_depth=48        # Number of CNN layers
-        self.encoder_mlp_layers=4        # Number of MLP layers
-        self.encoder_mlp_units=512       # Units per MLP layer
-        self.encoder_act="SiLU"          # Activation function
-        self.encoder_norm="layer"        # Normalization (e.g., LayerNorm)
-        self.encoder_kernel_size=4       # CNN kernel size
-        self.encoder_minres=4            # Minimum resolution for CNN
-        self.encoder_symlog_inputs=False # No symlog for LiDAR (unless needed)
-
-        # PARAMS for networks.MultiDecoder
-        self.feat_size = 1024           # Size of latent features
-        self.decoder_cnn_sigmoid = True  # Sigmoid for image outputs (pixel values in [0, 1])
-        self.decoder_image_dist = "mse"  # MSE loss for images
-        self.decoder_vector_dist = "normal" # Gaussian loss for LiDAR
-        self.decoder_outscale = 1.0      # Output scaling factor

--- a/src/dreamer_node/util/constants.py
+++ b/src/dreamer_node/util/constants.py
@@ -161,3 +161,26 @@ class Config:
             "encoder": {"mlp_keys": ".*", "cnn_keys": "$^"},
             "decoder": {"mlp_keys": ".*", "cnn_keys": "$^"},
         }
+
+        # PARAMS for networks.MultiEncoder for image data and LiDAR data
+        self.shapes = {
+            "image": (64, 64, 3),  # Image input
+            "lidar": (1080,),      # LiDAR input
+        }
+        self.encoder_cnn_keys = "image"
+        self.encoder_mlp_keys = "lidar"
+        self.encoder_cnn_depth=48        # Number of CNN layers
+        self.encoder_mlp_layers=4        # Number of MLP layers
+        self.encoder_mlp_units=512       # Units per MLP layer
+        self.encoder_act="SiLU"          # Activation function
+        self.encoder_norm="layer"        # Normalization (e.g., LayerNorm)
+        self.encoder_kernel_size=4       # CNN kernel size
+        self.encoder_minres=4            # Minimum resolution for CNN
+        self.encoder_symlog_inputs=False # No symlog for LiDAR (unless needed)
+
+        # PARAMS for networks.MultiDecoder
+        self.feat_size = 1024           # Size of latent features
+        self.decoder_cnn_sigmoid = True  # Sigmoid for image outputs (pixel values in [0, 1])
+        self.decoder_image_dist = "mse"  # MSE loss for images
+        self.decoder_vector_dist = "normal" # Gaussian loss for LiDAR
+        self.decoder_outscale = 1.0      # Output scaling factor


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I got the constants needed to make the MultiEncoder and MultiDecoder compatible for a 1D LiDAR array and a 2d image. This includes keys for a CNN (for the image) and MLP (for the LiDAR data). I put them in src/dreamer_node/util/constants.py.

## Related Issue

N/A

## Motivation and Context

In the dreamerv3 code, the parameters for the encoder and decoder are taken from the config.yaml file. Since we are not using a config file. These parameters need to be set as constants. Additionally, the necessary setup for the MLP and CNN are needed.

## How Has This Been Tested?

Not yet testable.

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/e76eeb43-fbc9-4fed-b651-460a1e4857d3)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help. -->

- [ ] My code involves a change to the database schema.
- [ ] My code requires a change to the documentation.
