### PR TITLE
(In progress, don't close yet) Debugging experience replay storage problems for racecar_gym to dreamer

### DIFF
--- a/dreamer_node/dreamer/config.py
+++ b/dreamer_node/dreamer/config.py
@@ -12,7 +12,7 @@ class Config:
     steps = int(1e6)  # Updated from f1tenth
     parallel = False
     eval_every = int(1e4)
-    eval_episode_num = 10
+    eval_episode_num = 5
     log_every = int(1e4)
     reset_every = 0
     device = "cuda:0"

--- a/dreamer_node/dreamer/config.py
+++ b/dreamer_node/dreamer/config.py
@@ -12,7 +12,7 @@ class Config:
     steps = int(1e6)  # Updated from f1tenth
     parallel = False
     eval_every = int(1e4)
-    eval_episode_num = 1
+    eval_episode_num = 10
     log_every = int(1e4)
     reset_every = 0
     device = "cuda:0"

--- a/dreamer_node/dreamer/dream.py
+++ b/dreamer_node/dreamer/dream.py
@@ -74,6 +74,9 @@ class Dreamer(nn.Module):
             )
 
             for _ in range(steps):
+                # print("SAMPLED DATASET")
+                # next_dataset = next(self._dataset)
+                # print(next_dataset)
                 self._train(next(self._dataset))
                 self._update_count += 1
                 self._metrics["update_count"] = self._update_count

--- a/dreamer_node/dreamer/racecar_env.py
+++ b/dreamer_node/dreamer/racecar_env.py
@@ -25,6 +25,10 @@ class Racecar:
                 render_options=dict(width=320, height=240, agent="A"),  # optional
             )
         self.reward_range = [-np.inf, np.inf]
+        
+        # Impose 100 step limit on environment until debugging is done
+        self.steps_taken = 0
+        self.step_limit = 100
 
     @property
     def observation_space(self):
@@ -60,6 +64,11 @@ class Racecar:
             racecar_action = action
         base_obs, reward, done, truncated, info = self._env.step(racecar_action)
 
+        self.steps_taken += 1
+        if self.steps_taken >= 100:
+            truncated = True
+            done = True
+
         obs = {
             "image": np.array(base_obs["hd_camera"], dtype=np.uint8),  # Ensure uint8
             "is_first": np.array([False], dtype=np.float32),
@@ -79,6 +88,7 @@ class Racecar:
 
     def reset(self, seed=None, options=None):
         base_obs, info = self._env.reset(seed=seed, options=options)
+        self.steps_taken = 0
 
         obs = {
             "image": np.array(base_obs["hd_camera"], dtype=np.uint8),  # Ensure uint8

--- a/dreamer_node/dreamer/racecar_env.py
+++ b/dreamer_node/dreamer/racecar_env.py
@@ -29,6 +29,7 @@ class Racecar:
         # Impose 100 step limit on environment until debugging is done
         self.steps_taken = 0
         self.step_limit = 100
+        self.train = train
 
     @property
     def observation_space(self):
@@ -65,7 +66,7 @@ class Racecar:
         base_obs, reward, done, truncated, info = self._env.step(racecar_action)
 
         self.steps_taken += 1
-        if self.steps_taken >= 100:
+        if not self.train and self.steps_taken >= 100:
             truncated = True
             done = True
 

--- a/dreamer_node/dreamer/tools.py
+++ b/dreamer_node/dreamer/tools.py
@@ -148,11 +148,11 @@ def simulate(
         agent_state = None
         reward = [0] * len(envs)
     else:
-        for thing in state:
-            print(thing)
+        # for thing in state:
+        #     print(thing)
         step, episode, done, length, obs, agent_state, reward = state
-    print("Step limit:", steps)
-    print("Episode limit:", episodes)
+    # print("Step limit:", steps)
+    # print("Episode limit:", episodes)
     while (steps and step < steps) or (episodes and episode < episodes):
         # reset envs if necessary
         if done.any():
@@ -211,7 +211,7 @@ def simulate(
             indices = [index for index, d in enumerate(done) if d]
             # logging for done episode
             for i in indices:
-                save_episodes(directory, {i: cache[i]}, steps=steps)
+                save_episodes(directory, {i: cache[i]})
                 print("Saved the episode")
                 length = len(cache[i]["reward"]) - 1
                 score = float(np.array(cache[i]["reward"]).sum())
@@ -300,8 +300,7 @@ def convert(value, precision=32):
     return value.astype(dtype)
 
 
-def save_episodes(directory, episodes, steps=0):
-    # Only print debug statements if steps = 0 (Evaluation)
+def save_episodes(directory, episodes):
     """directory = pathlib.Path(directory).expanduser()
     directory.mkdir(parents=True, exist_ok=True)
     for filename, episode in episodes.items():
@@ -335,8 +334,7 @@ def save_episodes(directory, episodes, steps=0):
                     # Try to stack assuming all arrays are the same shape.
                     processed_episode[key] = np.stack(value)
                 except Exception as e:
-                    if steps == 0:
-                        print(f"Could not stack key '{key}': {e}")
+                    print(f"Could not stack key '{key}': {e}")
                     # If stacking fails, convert each element.
                     processed_episode[key] = np.array(
                         [elem.item() if elem.size == 1 else elem for elem in value]
@@ -346,8 +344,7 @@ def save_episodes(directory, episodes, steps=0):
                 try:
                     processed_episode[key] = np.array(value)
                 except Exception as e:
-                    if steps == 0:
-                        print(f"Could not convert key '{key}' to array: {e}")
+                    print(f"Could not convert key '{key}' to array: {e}")
                     processed_episode[key] = value  # fallback if needed
 
             # Adjust `is_terminal` to ensure it's 2D
@@ -366,11 +363,9 @@ def save_episodes(directory, episodes, steps=0):
                     # print(f"{key}: type={arr_type}, shape={arr_shape}, unique values={unique_values}")
                     pass
                 else:
-                    if steps == 0:
-                        print(f"{key}: type={arr_type}, shape={arr_shape}")
+                    print(f"{key}: type={arr_type}, shape={arr_shape}")
             except Exception as e:
-                if steps == 0:
-                    print(f"{key}: type={type(arr)} (shape not available) due to: {e}")
+                print(f"{key}: type={type(arr)} (shape not available) due to: {e}")
 
         # Save the processed_episode to file.
         try:
@@ -380,8 +375,7 @@ def save_episodes(directory, episodes, steps=0):
                 with file_path.open("wb") as f2:
                     f2.write(f1.read())
         except Exception as e:
-            if steps == 0:
-                print(f"Failed to save episode {file_path}: {e}")
+            print(f"Failed to save episode {file_path}: {e}")
 
     return True
 

--- a/dreamer_node/dreamer/tools.py
+++ b/dreamer_node/dreamer/tools.py
@@ -148,7 +148,11 @@ def simulate(
         agent_state = None
         reward = [0] * len(envs)
     else:
+        for thing in state:
+            print(thing)
         step, episode, done, length, obs, agent_state, reward = state
+    print("Step limit:", steps)
+    print("Episode limit:", episodes)
     while (steps and step < steps) or (episodes and episode < episodes):
         # reset envs if necessary
         if done.any():
@@ -207,7 +211,8 @@ def simulate(
             indices = [index for index, d in enumerate(done) if d]
             # logging for done episode
             for i in indices:
-                save_episodes(directory, {i: cache[i]})
+                save_episodes(directory, {i: cache[i]}, steps=steps)
+                print("Saved the episode")
                 length = len(cache[i]["reward"]) - 1
                 score = float(np.array(cache[i]["reward"]).sum())
                 video = cache[i]["image"]
@@ -295,7 +300,8 @@ def convert(value, precision=32):
     return value.astype(dtype)
 
 
-def save_episodes(directory, episodes):
+def save_episodes(directory, episodes, steps=0):
+    # Only print debug statements if steps = 0 (Evaluation)
     """directory = pathlib.Path(directory).expanduser()
     directory.mkdir(parents=True, exist_ok=True)
     for filename, episode in episodes.items():
@@ -329,7 +335,8 @@ def save_episodes(directory, episodes):
                     # Try to stack assuming all arrays are the same shape.
                     processed_episode[key] = np.stack(value)
                 except Exception as e:
-                    print(f"Could not stack key '{key}': {e}")
+                    if steps == 0:
+                        print(f"Could not stack key '{key}': {e}")
                     # If stacking fails, convert each element.
                     processed_episode[key] = np.array(
                         [elem.item() if elem.size == 1 else elem for elem in value]
@@ -339,7 +346,8 @@ def save_episodes(directory, episodes):
                 try:
                     processed_episode[key] = np.array(value)
                 except Exception as e:
-                    print(f"Could not convert key '{key}' to array: {e}")
+                    if steps == 0:
+                        print(f"Could not convert key '{key}' to array: {e}")
                     processed_episode[key] = value  # fallback if needed
 
             # Adjust `is_terminal` to ensure it's 2D
@@ -358,9 +366,11 @@ def save_episodes(directory, episodes):
                     # print(f"{key}: type={arr_type}, shape={arr_shape}, unique values={unique_values}")
                     pass
                 else:
-                    print(f"{key}: type={arr_type}, shape={arr_shape}")
+                    if steps == 0:
+                        print(f"{key}: type={arr_type}, shape={arr_shape}")
             except Exception as e:
-                print(f"{key}: type={type(arr)} (shape not available) due to: {e}")
+                if steps == 0:
+                    print(f"{key}: type={type(arr)} (shape not available) due to: {e}")
 
         # Save the processed_episode to file.
         try:
@@ -370,7 +380,8 @@ def save_episodes(directory, episodes):
                 with file_path.open("wb") as f2:
                     f2.write(f1.read())
         except Exception as e:
-            print(f"Failed to save episode {file_path}: {e}")
+            if steps == 0:
+                print(f"Failed to save episode {file_path}: {e}")
 
     return True
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

I am still working on debugging the dreamer_node/dreamer/dream.py. 

I added a limit over in racecar_env.py that ends the episode after 100 steps. This is purely for debugging purposes.

I modified sample_episodes in tools.py to ensure that episodes from the experience replay are formatted properly. However, I am now getting inhomogeneous shape from numpy stacking in the from_generator. I believe this shows that there still data being stored improperly in the experience replay. 

To fix this I believe we will need to modify save_episodes in tools.py. This is where we need to ensure that the different keys for observations, rewards, and transitions are formatted consistently. Debugging this problem in sample_episodes (which occurs after the episodes are saved) was only delaying this issue.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help. -->

- [ ] My code involves a change to the f1tenth car hardware.
- [ ] My code requires a change to the documentation.
